### PR TITLE
Update version to 3.2 and change homepage.

### DIFF
--- a/Casks/popcorn-time.rb
+++ b/Casks/popcorn-time.rb
@@ -1,7 +1,7 @@
 class PopcornTime < Cask
-  url 'http://cdn.get-popcorn.com/build/Popcorn-Time-0.3.1-Mac.tar.gz'
-  homepage 'http://www.time4popcorn.eu/'
-  version '3.1'
-  sha256 :no_check
+  url 'http://cdn.popcorntime.io/build/Popcorn-Time-0.3.2-Mac.dmg'
+  homepage 'http://popcorntime.io/'
+  version '3.2'
+  sha256 'abeea0d1de945311d1552764a9842142c8d317ba7ea0b01c15d45f4bdd815206'
   link 'Popcorn-Time.app'
 end


### PR DESCRIPTION
I changed the homepage to a more trustworthy clone's. Time4popcorn is run in an iframe with the code hosted externally. This means that you really have no idea what is running on your machine. Source: http://www.reddit.com/r/PopCornTime/comments/241y7i/remember_to_tell_anybody_that_time4popcorn_is/
