### PR TITLE
Change URL back to popcorntime.io

### DIFF
--- a/Casks/popcorn-time.rb
+++ b/Casks/popcorn-time.rb
@@ -2,7 +2,7 @@ cask :v1 => 'popcorn-time' do
   version '0.3.6'
   sha256 '48419eaa34ab31ca071e010ff49c065ba23ad06bd8f1b50349308980e937dfeb'
 
-  url "http://popcorn.obsidian.goender.net/build/Popcorn-Time-#{version}-Mac.dmg"
+  url "https://cdn.popcorntime.io/build/Popcorn-Time-0.3.6-Mac.dmg"
   homepage 'http://popcorntime.io/'
   license :gpl
 


### PR DESCRIPTION
The last commit changed the download url to the pretty obscure http://popcorn.obsidian.goender.net
This shouldn't have happened. That site doesn't even say what it is (just a 403).